### PR TITLE
Add ROM information endpoint (closes #18)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -712,6 +712,7 @@ if ( ${REST_API} )
     ${CMAKE_CURRENT_SOURCE_DIR}/drivers/Qt/RestApi/FceuxApiServer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/drivers/Qt/RestApi/CommandQueue.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/drivers/Qt/RestApi/EmulationController.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/drivers/Qt/RestApi/RomInfoController.cpp
   )
 endif()
 

--- a/src/drivers/Qt/RestApi/FceuxApiServer.cpp
+++ b/src/drivers/Qt/RestApi/FceuxApiServer.cpp
@@ -3,6 +3,7 @@
 #include "../../../lib/json.hpp"
 #include "../../../version.h"
 #include "EmulationController.h"
+#include "RomInfoController.h"
 #include <QDateTime>
 #include <QtGlobal>
 
@@ -35,6 +36,9 @@ void FceuxApiServer::registerRoutes()
     addPostRoute("/api/emulation/pause", EmulationController::handlePause);
     addPostRoute("/api/emulation/resume", EmulationController::handleResume);
     addGetRoute("/api/emulation/status", EmulationController::handleStatus);
+    
+    // ROM information endpoint
+    addGetRoute("/api/rom/info", RomInfoController::handleRomInfo);
     
     // TODO: Add input validation framework for future POST/PUT endpoints
 }
@@ -91,7 +95,8 @@ void FceuxApiServer::handleSystemCapabilities(const httplib::Request& req, httpl
         "/api/system/capabilities",
         "/api/emulation/pause",
         "/api/emulation/resume",
-        "/api/emulation/status"
+        "/api/emulation/status",
+        "/api/rom/info"
     });
     
     // Feature flags

--- a/src/drivers/Qt/RestApi/RomInfoCommands.h
+++ b/src/drivers/Qt/RestApi/RomInfoCommands.h
@@ -1,0 +1,143 @@
+#ifndef __ROM_INFO_COMMANDS_H__
+#define __ROM_INFO_COMMANDS_H__
+
+#include "RestApiCommands.h"
+#include "../../../fceu.h"
+#include "../../../git.h"
+#include "../../../cart.h"
+#include <sstream>
+#include <iomanip>
+
+/**
+ * @brief ROM information structure
+ */
+struct RomInfo {
+    bool loaded;
+    std::string filename;
+    std::string name;
+    int size;
+    int mapper;
+    std::string mirroring;
+    bool has_battery;
+    std::string md5;
+    
+    /**
+     * @brief Convert mirroring value to string
+     * @param mirror Mirroring type value
+     * @return String representation of mirroring type
+     */
+    static std::string getMirroringString(int mirror) {
+        switch(mirror) {
+            case 0: return "horizontal";
+            case 1: return "vertical";
+            case 2: return "4screen";
+            case 3: return "none";
+            default: return "unknown";
+        }
+    }
+    
+    /**
+     * @brief Convert MD5 bytes to hex string
+     * @param md5 MD5 byte array
+     * @return Hex string representation
+     */
+    static std::string md5ToHexString(const uint8 md5[16]) {
+        std::ostringstream oss;
+        for (int i = 0; i < 16; i++) {
+            oss << std::hex << std::setfill('0') << std::setw(2) 
+                << static_cast<int>(md5[i]);
+        }
+        return oss.str();
+    }
+    
+    /**
+     * @brief Convert to JSON string
+     * @return JSON representation of the ROM info
+     */
+    std::string toJson() const {
+        std::ostringstream json;
+        json << "{";
+        json << "\"loaded\":" << (loaded ? "true" : "false");
+        
+        if (loaded) {
+            json << ",";
+            json << "\"filename\":\"" << filename << "\",";
+            json << "\"name\":\"" << name << "\",";
+            json << "\"size\":" << size << ",";
+            json << "\"mapper\":" << mapper << ",";
+            json << "\"mirroring\":\"" << mirroring << "\",";
+            json << "\"has_battery\":" << (has_battery ? "true" : "false") << ",";
+            json << "\"md5\":\"" << md5 << "\"";
+        }
+        
+        json << "}";
+        return json.str();
+    }
+};
+
+/**
+ * @brief Command to get ROM information
+ */
+class RomInfoCommand : public ApiCommandWithResult<RomInfo> {
+public:
+    void execute() override {
+        RomInfo info;
+        
+        // Check if ROM is loaded
+        if (!GameInfo) {
+            info.loaded = false;
+            resultPromise.set_value(info);
+            return;
+        }
+        
+        info.loaded = true;
+        
+        // Get filename - prefer regular filename over archive filename
+        if (GameInfo->filename) {
+            info.filename = GameInfo->filename;
+        } else if (GameInfo->archiveFilename) {
+            info.filename = GameInfo->archiveFilename;
+        } else {
+            info.filename = "";
+        }
+        
+        // Get game name (UTF-8 encoded)
+        if (GameInfo->name) {
+            info.name = reinterpret_cast<const char*>(GameInfo->name);
+        } else {
+            info.name = "";
+        }
+        
+        // Get mapper number
+        info.mapper = GameInfo->mappernum;
+        
+        // Calculate ROM size (PRG + CHR)
+        info.size = 0;
+        if (PRGsize[0] > 0) {
+            info.size += PRGsize[0];
+        }
+        if (CHRsize[0] > 0) {
+            info.size += CHRsize[0];
+        }
+        
+        // Get mirroring and battery info from CartInfo if available
+        if (currCartInfo) {
+            info.mirroring = RomInfo::getMirroringString(currCartInfo->mirror);
+            info.has_battery = (currCartInfo->battery != 0);
+        } else {
+            info.mirroring = "unknown";
+            info.has_battery = false;
+        }
+        
+        // Get MD5 hash
+        info.md5 = RomInfo::md5ToHexString(GameInfo->MD5.data);
+        
+        resultPromise.set_value(info);
+    }
+    
+    const char* name() const override {
+        return "RomInfoCommand";
+    }
+};
+
+#endif // __ROM_INFO_COMMANDS_H__

--- a/src/drivers/Qt/RestApi/RomInfoController.cpp
+++ b/src/drivers/Qt/RestApi/RomInfoController.cpp
@@ -1,0 +1,36 @@
+#include "RomInfoController.h"
+#include "RomInfoCommands.h"
+#include "CommandQueue.h"
+#include "CommandExecution.h"
+#include "../../../lib/httplib.h"
+#include <memory>
+#include <sstream>
+
+// Timeout for command execution (2 seconds)
+static constexpr unsigned int COMMAND_TIMEOUT_MS = 2000;
+
+void RomInfoController::handleRomInfo(const httplib::Request& req, httplib::Response& res) {
+    try {
+        // Create and execute ROM info command
+        auto cmd = std::unique_ptr<ApiCommandWithResult<RomInfo>>(new RomInfoCommand());
+        auto future = executeCommand(std::move(cmd), COMMAND_TIMEOUT_MS);
+        
+        // Wait for result
+        RomInfo info = waitForResult(future, COMMAND_TIMEOUT_MS);
+        
+        // Return ROM info as JSON
+        res.set_content(info.toJson(), "application/json");
+        res.status = 200;
+        
+    } catch (const std::exception& e) {
+        // Handle any exceptions
+        std::ostringstream json;
+        json << "{";
+        json << "\"success\":false,";
+        json << "\"error\":\"" << e.what() << "\"";
+        json << "}";
+        
+        res.status = 500;
+        res.set_content(json.str(), "application/json");
+    }
+}

--- a/src/drivers/Qt/RestApi/RomInfoController.h
+++ b/src/drivers/Qt/RestApi/RomInfoController.h
@@ -1,0 +1,22 @@
+#ifndef __ROM_INFO_CONTROLLER_H__
+#define __ROM_INFO_CONTROLLER_H__
+
+namespace httplib {
+    class Request;
+    class Response;
+}
+
+/**
+ * @brief REST API controller for ROM information endpoints
+ */
+class RomInfoController {
+public:
+    /**
+     * @brief Handle GET /api/rom/info endpoint
+     * @param req HTTP request
+     * @param res HTTP response
+     */
+    static void handleRomInfo(const httplib::Request& req, httplib::Response& res);
+};
+
+#endif // __ROM_INFO_CONTROLLER_H__


### PR DESCRIPTION
## Summary

This PR implements a REST API endpoint to retrieve information about the currently loaded ROM.

## Implementation Details

### Endpoint
- **GET** `/api/rom/info` - Returns comprehensive ROM metadata

### Architecture
- Created `RomInfoCommand` class that executes on emulator thread via command queue
- Gathers data from `GameInfo` and `CartInfo` structures
- Thread-safe access using existing mutex infrastructure
- Handles edge cases (no ROM loaded, missing data fields)

### Response Format

When no ROM is loaded:
```json
{"loaded": false}
```

When ROM is loaded:
```json
{
  "loaded": true,
  "filename": "/path/to/game.nes",
  "name": "Game Name",
  "size": 40976,
  "mapper": 0,
  "mirroring": "vertical",
  "has_battery": false,
  "md5": "811b027eaf99c2def7b933c5208636de"
}
```

## Testing

Tested successfully with:
- ✅ No ROM loaded - returns `{"loaded": false}`
- ✅ Final Fantasy (U).nes - correctly shows mapper 1, battery save, horizontal mirroring
- ✅ MD5 hash calculation working
- ✅ ROM size calculation (PRG + CHR)

## Example Usage

```bash
# Get ROM info
curl http://localhost:8080/api/rom/info
```

## Files Changed
- `RomInfoCommands.h` - ROM info data structure and command class
- `RomInfoController.cpp/h` - HTTP endpoint handler
- `FceuxApiServer.cpp` - Route registration
- `CMakeLists.txt` - Build configuration

Closes #18